### PR TITLE
全体的に余白や見出しのCSSを整える

### DIFF
--- a/2017kansai/assets/css/custom.css
+++ b/2017kansai/assets/css/custom.css
@@ -4,14 +4,6 @@
 **
 ***********************************************/
 
-/* common */
-
-body h4 {
-  font-weight: 700;
-  margin: 0;
-  padding: 10px 0;
-}
-
 /* buttons */
 
 .button a.btn-ticket {
@@ -80,20 +72,6 @@ ul.staff-list > li img {
   margin-bottom: 16px;
 }
 
-#special-session div.row {
-  margin: 20px 0;
-}
-
 #special-session article.description > p {
   margin-bottom: 1em;
-}
-
-/* about */
-#about .table {
-  margin-top: 5px;
-  margin-bottom: 0;
-}
-
-#about dt {
-  padding: 0;
 }

--- a/2017kansai/assets/css/html.pc.css
+++ b/2017kansai/assets/css/html.pc.css
@@ -292,8 +292,13 @@ dd img { vertical-align: bottom; }
 	text-shadow: 0px 0px 1px rgba(255, 255, 255, 1.0), 0px 0px 5px rgba(255, 51, 0, 1.0), 0px 0px 5px rgba(255, 51, 0, 1.0), 0px 0px 0px rgba(255, 255, 255, 1.0), 0px 0px 0px rgba(255, 51, 0, 1.0), 0px 0px 0px rgba(255, 51, 0, 1.0);
 	background: url(../images/title_base.gif) no-repeat center center;
 	background-size: 1000px;
-	margin: 20px 0 0 0;
 	padding: 10px 120px;
+}
+
+#container h4 {
+	font-size: 20px;
+	font-weight: 700;
+	margin-bottom: 10px;
 }
 
 #container .box .section {
@@ -302,24 +307,45 @@ dd img { vertical-align: bottom; }
 	-moz-background-size: auto 65px;
 	background-size: auto 65px;
 	margin: 0 auto;
-	padding: 40px 0;
 }
 
 #container .box .section .body {
 	text-align: justify;
 	text-justify: inter-ideograph;
-	padding: 20px 20px 40px;
+	padding: 60px 40px;
 }
 
-#container .box .section .body p {}
+#container dl {
+	width: 100%;
+	display: inline-block;
+	overflow: hidden;
+	margin-bottom: -20px;
+}
 
+#container dl dt {
+	float: left;
+	width: 6em;
+	margin-bottom: 20px;
+	padding: 7px 10px;
+	display: inline-block;
+	color: #fff;
+	font-size: 18px;
+	letter-spacing: 0.1em;
+	text-align: center;
+	background: #090922;
+}
+#container dl dd {
+	margin-bottom: 20px;
+	padding: 10px 15px;
+	padding-left: 8em;
+}
 
 /*----------------------------------------------------------
   - HOME
 ----------------------------------------------------------*/
 
 #button {
-	padding: 0px 15px;
+	padding: 25px 0 65px 0;
 	_zoom: 1;
 	overflow: hidden;
 }
@@ -375,28 +401,25 @@ dd img { vertical-align: bottom; }
         width: 500px;
 }
 
-#guest-speakers .row {
-	vertical-align: middle;
+.row + .row {
+	margin-top: 40px;
+}
+
+#sponsors h4 {
+	padding: 10px 15px;
 	margin-bottom: 20px;
+	font-size: 18px;
+	letter-spacing: 0.1em;
+	display: inline-block;
+	color: #fff;
+	background: #090922;
 }
 
-#guest-speakers .row > div h4 {
-	font-size: 16px;
-	font-weight: 700;
-	margin: 0;
-	padding: 10px 0;
-}
-
-#sponsors .class h4 {
-	font-size: 16px;
-	font-weight: 700;
-	margin: 0;
-	padding: 10px 0;
+#sponsors .class + .class {
+	margin-top: 40px;
 }
 
 #sponsors .class .block {
-	width: 770px;
-	_zoom: 1;
 	overflow: hidden;
 }
 
@@ -408,24 +431,22 @@ dd img { vertical-align: bottom; }
 #sponsors .class .block ul li {
 	float: left;
 	text-align: center;
-	margin: 0 10px 10px 0;
     display: flex;
     justify-content: center;
     align-items: center;
+	border: 5px solid #c9c9c9;
+	border-radius: 5px;
+}
 
-    box-shadow: 2px 2px 1px 1px #D0D0D0;
-    -moz-box-shadow: 2px 2px 1px 1px #D0D0D0;
-    -webkit-box-shadow: 2px 2px 1px 1px #D0D0D0;
+#sponsors .class .block ul li:first-child,
+#sponsors .class .block ul li + li {
+	margin: 0 20px 20px 0;
 }
 
 #sponsors .class .block ul li.large { width: 300px; height: 300px; }
 #sponsors .class .block ul li.medium { width: 220px; height: 220px; }
 #sponsors .class .block ul li.small { width: 150px; height: 150px; }
 #sponsors .class .block ul li img { height: auto; }
-#sponsors .class .block ul li.large img { padding: 40px; }
-#sponsors .class .block ul li.medium img  { padding: 10px; }
-#sponsors .class .block ul li.small img { padding: 5px; }
-
 
 /*----------------------------------------------------------
   - FOOTER / LOGO
@@ -537,4 +558,3 @@ aside #footer-logo {
 
 @media screen and (min-width: 0px) and (max-width: 768px) {
 }
-

--- a/2017kansai/assets/css/html.sp.css
+++ b/2017kansai/assets/css/html.sp.css
@@ -442,7 +442,6 @@ dd img { vertical-align: bottom; }
 	font-weight: 500;
 	text-shadow: 0px 0px 1px rgba(255, 255, 255, 1.0), 0px 0px 5px rgba(255, 51, 0, 1.0), 0px 0px 5px rgba(255, 51, 0, 1.0), 0px 0px 0px rgba(255, 255, 255, 1.0), 0px 0px 0px rgba(255, 51, 0, 1.0), 0px 0px 0px rgba(255, 51, 0, 1.0);
 	background-color: #090922;
-	margin: 20px 0 0 0;
 	padding: 8px 35px;
 }
 #container .box h3.title::before {
@@ -450,16 +449,11 @@ dd img { vertical-align: bottom; }
 	position: absolute;
 	left: 0;
 	top: 50%;
-
 	display: block;
 	width: 20px;
 	height: 10px;
 	background-color: #fff;
 	margin: -5px 0 0 0;
-}
-
-#container .box .section {
-	padding: 20px 0;
 }
 
 #container .box .section h3.title {
@@ -473,24 +467,59 @@ dd img { vertical-align: bottom; }
 	line-height: 20px;
 	margin: 10px 0 20px 0;
 	padding: 0;
+}
 
+#container h4 {
+	font-size: 20px;
+	font-weight: 700;
+	margin-bottom: 10px;
 }
 
 #container .box .section .body {
 	text-align: justify;
 	text-justify: inter-ideograph;
-	padding: 20px 10px 40px;
+	padding: 30px 20px;
 }
 
-#container .box .section .body p {}
+#container dl {
+	width: 100%;
+	display: inline-block;
+	overflow: hidden;
+	margin-bottom: -20px;
+}
 
+#container dl dt {
+	float: left;
+	width: 6em;
+	margin-bottom: 10px;
+	padding: 7px 10px;
+	display: inline-block;
+	color: #fff;
+	font-size: 14px;
+	letter-spacing: 0.1em;
+	text-align: center;
+	background: #090922;
+}
+#container dl dd {
+	margin-bottom: 10px;
+	padding: 10px 15px;
+	padding-left: 7em;
+}
+
+#container #access dl dt {
+	float: none;
+}
+
+ #container #access dl dd {
+	padding-left: 0;
+}
 
 /*----------------------------------------------------------
   - HOME
 ----------------------------------------------------------*/
 
 #button {
-	padding: 0px 15px;
+	padding-bottom: 50px;
 	_zoom: 1;
 	overflow: hidden;
 }
@@ -553,7 +582,29 @@ dd img { vertical-align: bottom; }
 	margin: 0 auto;
 }
 
-#guest-speakers .row {
+#about .row + .row {
+	margin-top: 20px;
+}
+
+.row + .row {
+	margin-top: 40px;
+}
+
+#sponsors h4 {
+	padding: 10px 15px;
+	margin-bottom: 20px;
+	font-size: 14px;
+	letter-spacing: 0.1em;
+	display: inline-block;
+	color: #fff;
+	background: #090922;
+}
+
+#sponsors .class + .class {
+	margin-top: 40px;
+}
+
+/*#guest-speakers .row {
 	vertical-align: middle;
 	margin-bottom: 20px;
 }
@@ -563,19 +614,15 @@ dd img { vertical-align: bottom; }
 	font-weight: 700;
 	margin: 0;
 	padding: 10px 0;
-}
+}*/
 
 #guest-speakers .row .col-md-3,
 #special-session .row .col-md-3 { text-align: center; }
 
 #guest-speakers .row .col-md-3 img,
-#special-session .row .col-md-3 img { max-width: 250px }
-
-#sponsors .class h4 {
-	font-size: 16px;
-	font-weight: 700;
-	margin: 0;
-	padding: 10px 0;
+#special-session .row .col-md-3 img {
+	max-width: 200px;
+	margin-bottom: 20px;
 }
 
 #sponsors .class .block {
@@ -595,19 +642,14 @@ dd img { vertical-align: bottom; }
     display: flex;
     justify-content: center;
     align-items: center;
-
-    box-shadow: 2px 2px 1px 1px #D0D0D0;
-    -moz-box-shadow: 2px 2px 1px 1px #D0D0D0;
-    -webkit-box-shadow: 2px 2px 1px 1px #D0D0D0;
+	border: 5px solid #c9c9c9;
+	border-radius: 5px;
 }
 
-#sponsors .class .block ul li.large { width: 300px; height: 300px; }
-#sponsors .class .block ul li.medium { width: 220px; height: 220px; }
-#sponsors .class .block ul li.small { width: 150px; height: 150px; }
+#sponsors .class .block ul li.large { width: 100%; }
+#sponsors .class .block ul li.medium { width: 80%; }
+#sponsors .class .block ul li.small { width: 45%; }
 #sponsors .class .block ul li img { height: auto; }
-#sponsors .class .block ul li.large img { padding: 40px; }
-#sponsors .class .block ul li.medium img  { padding: 10px; }
-#sponsors .class .block ul li.small img { padding: 5px; }
 
 /*----------------------------------------------------------
   - FOOTER / LOGO
@@ -720,4 +762,3 @@ aside #footer-logo {
 
 @media screen and (min-width: 0px) and (max-width: 768px) {
 }
-

--- a/2017kansai/index.html
+++ b/2017kansai/index.html
@@ -100,13 +100,11 @@
                     今回のYAPC::Kansaiでは、「温故知新」をテーマに、ベテランから若人まで幅広い年代の方々が楽しめる企画を準備しています。ぜひおいでやす！
                   </p>
                 </div>
-                <dl class="table row">
-                  <dt class="col-md-1">日時</dt>
-                  <dd class="col-md-9"><time datetime="2017-03-04T10:00:00+0900">2017/03/04 10:00</time> 〜 </dd>
-                </dl>
-                <dl class="table row">
-                  <dt class="col-md-1">会場</dt>
-                  <dd class="col-md-9"><a href="#access">アクセス</a></dd>
+                <dl class="row">
+                  <dt>日時</dt>
+                  <dd><time datetime="2017-03-04T10:00:00+0900">2017/03/04 10:00</time> 〜 </dd>
+                  <dt>会場</dt>
+                  <dd><a href="#access">アクセス</a></dd>
                 </dl>
               </div><!--  / .body /  -->
             </div><!--  / .section /  -->
@@ -399,16 +397,12 @@
             <div class="section" id="access">
               <div class="body">
                 <dl class="table row">
-                  <dt class="col-md-2">会場名</dt>
-                  <dd class="col-md-8">MOTEXホール（エムオーテックス株式会社）</dd>
-                </dl>
-                <dl class="table row">
-                  <dt class="col-md-2">会場URL</dt>
-                  <dd class="col-md-8"><a href="http://www.motex.co.jp/" target="_blank">http://www.motex.co.jp/company/base/</a></dd>
-                </dl>
-                <dl class="table row">
-                  <dt class="col-md-2">最寄り駅</dt>
-                  <dd class="col-md-8">JR新大阪駅(正面口)より徒歩約7分<br />地下鉄御堂筋線新大阪駅(7番出口)より 徒歩約5分<br />地下鉄御堂筋線西中島南方駅(1番出口)より 徒歩約5分</dd>
+                  <dt>会場名</dt>
+                  <dd>MOTEXホール（エムオーテックス株式会社）</dd>
+                  <dt>会場URL</dt>
+                  <dd><a href="http://www.motex.co.jp/" target="_blank">http://www.motex.co.jp/company/base/</a></dd>
+                  <dt>最寄り駅</dt>
+                  <dd>JR新大阪駅(正面口)より徒歩約7分<br />地下鉄御堂筋線新大阪駅(7番出口)より 徒歩約5分<br />地下鉄御堂筋線西中島南方駅(1番出口)より 徒歩約5分</dd>
                 </dl>
                 <div class="iframe">
                   <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3279.032837472455!2d135.4971622287249!3d34.72956665572035!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x6000e43b1da92f05%3A0x50d5f0482be9dc33!2z44Ko44Og44Kq44O844OG44OD44Kv44K577yI5qCq77yJ!5e0!3m2!1sja!2sjp!4v1480585642539" width="800" height="600" frameborder="0" style="border:0" allowfullscreen></iframe>


### PR DESCRIPTION
### 作業につきまして

以下について作業を行いました。

- 各セクション内の上下の余白が不揃いだったので統一
- 「About」「Sponsors」「Access」の見出しに背景色をしいてメリハリをつける
- スピーカー様のお名前のフォントサイズを上げる
- スピーカー様のお写真のサイズを縮小（スマホのみ）
- ロゴのCSSでの余白を削除
- ロゴの影を囲みボーダーに変更

### ご確認くださいませ

表示確認用スクショをはっておきます。
左が修正前、右が修正後です。
お手数おかけしてしまい、大変恐縮ですが、ご確認よろしくお願いいたします 🙏 

-----

#### PC
![pc](https://cloud.githubusercontent.com/assets/4636929/22404863/fce4132e-e67c-11e6-8c45-300c2b32fe2f.jpg)

-----

#### スマホ
![sp](https://cloud.githubusercontent.com/assets/4636929/22404864/fd12630a-e67c-11e6-8976-06ce2e9b5a1c.jpg)
